### PR TITLE
Fix badge placement instructions in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -72,7 +72,7 @@
 	- Don't include both a title saying `Awesome X` and a logo with `Awesome X`. You can put the header image in a `#` (Markdown header) or `<h1>`.
 - [ ] Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
 - [ ] Includes the [Awesome badge](https://github.com/sindresorhus/awesome/blob/main/awesome.md#awesome-badge).
-	- Should be placed on the right side of the readme heading.
+	- Should be placed after the main heading (not inline with the heading).
 		- Can be placed centered if the list has a centered graphics header.
 	- Should link back to this list.
 - [ ] Has a Table of Contents section.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#3969](https://github.com/sindresorhus/awesome/pull/3969)
> **Original author:** @tysoncung
> **Originally opened:** 2026-02-28

---

This PR fixes the contradiction between the pull request template and the awesome-lint tool regarding badge placement.

**Problem:**
- The PR template instructed users to place the Awesome badge 'on the right side of the readme heading'
- The awesome-lint tool expects the badge to be placed after the main heading, not inline with it
- This was causing linting failures when users followed the PR template instructions

**Solution:**
Updated the instruction in the PR template to clarify that the badge should be placed after the main heading, which matches both the linter expectations and the guidance in awesome.md.

Fixes #2097
