### PR TITLE
ci-cd (repo): add spam detector GH action

### DIFF
--- a/.github/workflows/spam_detector.yaml
+++ b/.github/workflows/spam_detector.yaml
@@ -1,0 +1,26 @@
+name: Spam Detection
+on:
+  schedule:
+    - cron: '0 17 * * 1-5'  # Every weekday (Monday-Friday) at 5 PM
+  workflow_dispatch: # Allows you to manually trigger the workflow as needed.
+jobs:
+  detect-spam:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      discussions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache cursor
+        uses: actions/cache@v3
+        with:
+          path: .github/cursor_cache
+          key: ${{ runner.os }}-cursor-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-cursor-
+      - name: Spam Detection
+        uses: Sambhaji-Patil/Auto-Hide-Spam-Comments@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#3479](https://github.com/sindresorhus/awesome/pull/3479)
> **Original author:** @hesreallyhim
> **Originally opened:** 2025-06-10

---

Fixes: 

This PR adds a new GH workflows action that auto-detects spam comments.

https://github.com/marketplace/actions/autohide-spam-comments

It doesn't have any reviews really, so I'm not sure how reliable it is, but I thought it might be worth trying.
