### PR TITLE
Fix Google Cloud name next to Firebase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@
 - [Flutter](https://github.com/Solido/awesome-flutter#readme) - Google's mobile SDK for building native iOS and Android apps from a single codebase written in Dart.
 - [Home Assistant](https://github.com/frenck/awesome-home-assistant#readme) - Open source home automation that puts local control and privacy first.
 - [IBM Cloud](https://github.com/victorshinya/awesome-ibmcloud#readme) - Cloud platform for developers and companies.
-- [Firebase](https://github.com/jthegedus/awesome-firebase#readme) - App development platform built on Google Cloud Platform.
+- [Firebase](https://github.com/jthegedus/awesome-firebase#readme) - App development platform built on Google Cloud.
 - [Robot Operating System 2.0](https://github.com/fkromer/awesome-ros2#readme) - Set of software libraries and tools that help you build robot apps.
 - [Adafruit IO](https://github.com/adafruit/awesome-adafruitio#readme) - Visualize and store data from any device.
 - [Cloudflare](https://github.com/irazasyed/awesome-cloudflare#readme) - CDN, DNS, DDoS protection, and security for your site.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#3004](https://github.com/sindresorhus/awesome/pull/3004)
> **Original author:** @rsamborski
> **Originally opened:** 2024-03-25

---

Minor naming fix: Google Cloud Platform -> Google Cloud.
