### PR TITLE
Update link to Awesome Web Components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,7 +354,7 @@
 - [React](https://github.com/enaqx/awesome-react#readme) - JavaScript library for building user interfaces.
 	- [Relay](https://github.com/expede/awesome-relay#readme) - Framework for building data-driven React apps.
 	- [React Hooks](https://github.com/glauberfc/awesome-react-hooks#readme) - Lets you use state and other React features without writing a class.
-- [Web Components](https://github.com/mateusortiz/webcomponents-the-right-way#readme)
+- [Web Components](https://github.com/web-padawan/awesome-web-components#readme)
 - [Polymer](https://github.com/Granze/awesome-polymer#readme) - JavaScript library to develop Web Components.
 - [Angular](https://github.com/PatrickJS/awesome-angular#readme) - App framework.
 - [Backbone](https://github.com/sadcitizen/awesome-backbone#readme) - App framework.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#2459](https://github.com/sindresorhus/awesome/pull/2459)
> **Original author:** @web-padawan
> **Originally opened:** 2022-12-19

---

This PR updates the link to the Web Components awesome list, which has been transferred and renamed:

- Before: https://github.com/mateusortiz/webcomponents-the-right-way
- After: https://github.com/web-padawan/awesome-web-components

Background: @mateusortiz has created this repo, but he no longer works on maintaining it.
We agreed on this with Mateus as he has been inactive on GitHub for more than 2 years.

Also note that I've been maintaining this list since December 2018 for more than 4 years - see [this post](https://dev.to/webpadawan/web-components-the-right-way-project-relaunch-20d7).
For more on the reason for renaming see this PR: https://github.com/web-padawan/awesome-web-components/pull/69

hanks in advance for taking a look at this PR 🙏  I'll try to do my best to review two PRs in this repository.
