### PR TITLE
Fix git diff command in repo linter

### DIFF
--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -2,7 +2,7 @@
 
 # Find the repo in the git diff and then set it to an env variables.
 REPO_TO_LINT=$(
-	git diff main readme.md |
+	git diff main -- readme.md |
 	# Look for changes (indicated by lines starting with +).
 	grep ^+ |
 	# Get the line that includes the readme.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#2003](https://github.com/sindresorhus/awesome/pull/2003)
> **Original author:** @RayBB
> **Originally opened:** 2021-05-02

---

Addresses https://github.com/sindresorhus/awesome/pull/1962#issuecomment-830787984

The problem was that you need to add a `--` between the branch and the file path.
https://git-scm.com/docs/git-diff

Maybe I removed that part by accident when refactoring the code.

Anyway, this is working now.

Sorry for the hiccup @sindresorhus 
