### PR TITLE
Correct links to two Awesome lists whose username had changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -507,8 +507,8 @@
 - [Incident Response](https://github.com/meirwah/awesome-incident-response#readme)
 - [Vehicle Security and Car Hacking](https://github.com/jaredthecoder/awesome-vehicle-security#readme)
 - [Web Security](https://github.com/qazbnm456/awesome-web-security#readme) - Security of web apps & services.
-- [Lockpicking](https://github.com/meitar/awesome-lockpicking#readme) - The art of unlocking a lock by manipulating its components without the key.
-- [Cybersecurity Blue Team](https://github.com/meitar/awesome-cybersecurity-blueteam#readme) - Groups of individuals who identify security flaws in information technology systems.
+- [Lockpicking](https://github.com/fabacab/awesome-lockpicking#readme) - The art of unlocking a lock by manipulating its components without the key.
+- [Cybersecurity Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam#readme) - Groups of individuals who identify security flaws in information technology systems.
 - [Fuzzing](https://github.com/cpuu/awesome-fuzzing#readme) - Automated software testing technique that involves feeding pseudo-randomly generated input data.
 - [Embedded and IoT Security](https://github.com/fkie-cad/awesome-embedded-and-iot-security#readme)
 - [GDPR](https://github.com/bakke92/awesome-gdpr#readme) - Regulation on data protection and privacy for all individuals within EU.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#1913](https://github.com/sindresorhus/awesome/pull/1913)
> **Original author:** @fabacab
> **Originally opened:** 2020-11-28

---

This PR makes no substantive changes to the list. Instead, it simply corrects links to two lists I maintain by updating the URL referencing their GitHub repository addresses, which future-proofs the links in the event their current redirects stop working.
