### PR TITLE
Change link from sysadmin repo to sysadmin forum

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -605,7 +605,7 @@
 	- [Datasets](https://github.com/jdorfman/awesome-json-datasets#readme)
 - [CSV](https://github.com/secretGeek/awesomeCSV#readme) - A text file format that stores tabular data and uses a comma to separate values.
 - [Discounts for Student Developers](https://github.com/AchoArnold/discount-for-student-dev#readme)
-- [Sysadmin](https://github.com/n1trux/awesome-sysadmin#readme)
+- [Sysadmin](https://awesome.tilde.fun/t/sysadmin)
 - [Radio](https://github.com/kyleterry/awesome-radio#readme)
 - [Awesome](https://github.com/sindresorhus/awesome#readme) - Recursion illustrated.
 - [Analytics](https://github.com/onurakpolat/awesome-analytics#readme)


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#1904](https://github.com/sindresorhus/awesome/pull/1904)
> **Original author:** @n1trux
> **Originally opened:** 2020-11-15

---

Hi, I decided to archive [my awesome-sysadmin list](https://github.com/n1trux/awesome-sysadmin) and move it to a Flarum installation I manage:

https://awesome.tilde.fun/t/sysadmin

While this certainly means that the list can be inaccessible at any time, I try to make sure to host it indefinitely. Flarum uses Markdown format and I'm sure we can find a way to mirror this to a git repository somehow.

The reason for my decision is that searching via tags and discussing the software is way easier in Flarum than it is in a Github markdown list. I will try to create an extension to mirror the layout/design of the initial markdown list with a powerful search interface, but for now I think Flarum's search features are good enough™.

I'll enable Github OAuth access so everyone with a Github account can log in into the awesome-sysadmin forum and contribute there.

Tagging @nodiscc and @Kickball for consideration.
