### PR TITLE
Add awesome-rxswift

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@
 - [Swift](https://github.com/matteocrippa/awesome-swift#readme)
 	- [Education](https://github.com/hsavit1/Awesome-Swift-Education#readme)
 	- [Playgrounds](https://github.com/uraimo/Awesome-Swift-Playgrounds#readme)
+	- [RxSwift](https://github.com/LeoMobileDeveloper/awesome-rxswift#readme)
 - [Python](https://github.com/vinta/awesome-python#readme)
 	- [Asyncio](https://github.com/timofurrer/awesome-asyncio#readme) - Asynchronous I/O in Python 3.
 	- [Scientific Audio](https://github.com/faroit/awesome-python-scientific-audio#readme) - Scientific research in audio/music.

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@
 - [Swift](https://github.com/matteocrippa/awesome-swift#readme)
 	- [Education](https://github.com/hsavit1/Awesome-Swift-Education#readme)
 	- [Playgrounds](https://github.com/uraimo/Awesome-Swift-Playgrounds#readme)
-	- [RxSwift](https://github.com/LeoMobileDeveloper/awesome-rxswift#readme)
+	- [RxSwift](https://github.com/LeoMobileDeveloper/awesome-rxswift#readme) Reactive Programming in Swift
 - [Python](https://github.com/vinta/awesome-python#readme)
 	- [Asyncio](https://github.com/timofurrer/awesome-asyncio#readme) - Asynchronous I/O in Python 3.
 	- [Scientific Audio](https://github.com/faroit/awesome-python-scientific-audio#readme) - Scientific research in audio/music.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#1351](https://github.com/sindresorhus/awesome/pull/1351)
> **Original author:** @LeoMobileDeveloper
> **Originally opened:** 2018-07-11

---

<!-- Congrats on creating an Awesome list! 🎉 -->


<!-- Please fill in the below placeholders -->

**https://github.com/LeoMobileDeveloper/awesome-rxswift**

**This repo contains curated list of RxSwift library and learning material**

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

**Please read it multiple times. I spent a lot of time on these guidelines and most people miss a lot.**

## Requirements for your pull request

- I have read and understood the [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/contributing.md) and the [instructions for creating a list](https://github.com/sindresorhus/awesome/blob/master/create-list.md).
- This pull request has a descriptive title.<br>For example, `Add Name of List`, not `Update readme.md` or `Add awesome list`.
- The entry in the Awesome list should:
	- Include a short description about the project/theme of the list. **It should not describe the list itself.**<br>Example: `- [Fish](…) - User-friendly shell.`, not `- [Fish](…) - Resources for Fish.`.
	- Be added at the bottom of the appropriate category.
- The list I'm submitting complies with these requirements:


## Requirements for your Awesome list

- **Has been around for at least 30 days.**<br>That means 30 days from either the first real commit or when it was open-sourced. Whatever is most recent.
- It's the result of hard work and the best I could possibly produce.
- Non-generated Markdown file in a GitHub repo.
- **Includes a succinct description of the project/theme at the top of the readme.** [(Example)](https://github.com/willempienaar/awesome-quantified-self)
- The repo should have `awesome-list` & `awesome` as [GitHub topics](https://help.github.com/articles/about-topics). I encourage you to add more relevant topics.
- Not a duplicate.
- Only has awesome items. Awesome lists are curations of the best, not everything.
- Includes a project logo/illustration whenever possible.
	- Either fullwidth or placed at the top-right of the readme. [(Example)](https://github.com/sindresorhus/awesome-electron)
	- The image should link to the project website or any relevant website.
	- The image should be high-DPI. Set it to maximum half the width of the original image.
- Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
- Includes the [Awesome badge](https://github.com/sindresorhus/awesome/blob/master/awesome.md#awesome-badge).
	- Should be placed on the right side of the readme heading.
	- Should link back to this list.
- Has a Table of Contents section.
	- Should be named `Contents`, not `Table of Contents`.
	- Should be the first section in the list.
	- Should only have one level of sub-lists, preferably none.
- Has an [appropriate license](https://github.com/sindresorhus/awesome/blob/master/awesome.md#choose-an-appropriate-license).
	- That means something like CC0, **not a code licence like MIT, BSD, Apache, etc.**
	- [WTFPL](http://www.wtfpl.net) and [Unlicense](http://unlicense.org) are not acceptable licenses.
	- If you use a license badge, it should be SVG, not PNG.
- Has [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/awesome.md#include-contribution-guidelines).
	- The file should be named `contributing.md`. Casing is up to you.
- Has consistent formatting and proper spelling/grammar.
	- The link and description are separated by a dash. <br>Example: `- [AVA](…) - JavaScript test runner.`
	- The description starts with an uppercase character and ends with a period.
	- Consistent and correct naming. For example, `Node.js`, not `NodeJS` or `node.js`.
- Doesn't include a Travis badge.<br>You can still use Travis for list linting, but the badge has no value in the readme.

Go to the top and read it again.
