### PR TITLE
Fix Broken Link to Effective Altruism

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -569,7 +569,7 @@
 - [Magento 2](https://github.com/DavidLambauer/awesome-magento2) - Open Source eCommerce built with PHP.
 - [TikZ](https://github.com/xiaohanyu/awesome-tikz) - Graph drawing packages for TeX/LaTeX/ConTeXt.
 - [Neuroscience](https://github.com/analyticalmonk/awesome-neuroscience) - Study of the nervous system and brain.
-- [Effective Altruism](https://github.com/sheonhan/awesome-effective-altruism) - Evidence-driven philanthropy.
+- [Effective Altruism](https://github.com/ShriSamson/awesome-effective-altruism) - Evidence-driven philanthropy.
 - [Ad-Free](https://github.com/johnjago/awesome-ad-free) - Ad-free alternatives.
 - [Esolangs](https://github.com/angrykoala/awesome-esolangs) - Programming languages designed for experimentation or as jokes rather than actual use.
 - [Prometheus](https://github.com/roaldnefs/awesome-prometheus) - Open-source monitoring system.


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#1235](https://github.com/sindresorhus/awesome/pull/1235)
> **Original author:** @stella-lu
> **Originally opened:** 2018-03-05

---

The link to Effective Altruism (under miscellaneous) was broken, but I found what I assume is the same thing here:
https://github.com/ShriSamson/awesome-effective-altruism
