### PR TITLE
Remove Endangered Languages list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -448,7 +448,6 @@
 - [REST](https://github.com/marmelab/awesome-rest)
 - [Selenium](https://github.com/christian-bromann/awesome-selenium)
 - [Appium](https://github.com/SrinivasanTarget/awesome-appium) - Test automation tool for apps.
-- [Endangered Languages](https://github.com/RichardLitt/endangered-languages)
 - [Continuous Delivery](https://github.com/ciandcd/awesome-ciandcd)
 - [Services Engineering](https://github.com/mmcgrana/services-engineering)
 - [Free for Developers](https://github.com/ripienaar/free-for-dev)


### PR DESCRIPTION
> **Copied from upstream:** [sindresorhus/awesome#936](https://github.com/sindresorhus/awesome/pull/936)
> **Original author:** @RichardLitt
> **Originally opened:** 2017-04-17

---

I believe that RichardLitt/endangered-languages _is_ an awesome list. However, it does not match
the stipulations set in https://github.com/sindresorhus/awesome/issues/926 as to what an awesome
list should look like. For instance, I use GitHub descriptions instead of other descriptions for
repositories. I also include everything I can, because that is the point of the list - we use
stars to show what is popular, which is a metric of awesome contents, as opposed to having only
awesome contents. I do not want to change the whole list to match the awesome-styleguides, as that
would be arduous and I am not convinced it would improve the point of the list.

I have written about this list elsewhere, and I would like to keep it as it is currently formatted,
although I agree that it would be great if it were better in places. However, I'll get to that
when I get to it. For now, I am making this PR to suggest that the list be removed. I'd rather it
was not, but I'm trying to be respectful of @sindresorhus's wishes for list standards.
